### PR TITLE
Fix document query API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# HACKRX 6.0 - LLM Document Query API
+
+This FastAPI service lets you upload a PDF file and ask questions about its contents. It extracts text using PyMuPDF and forwards the question along with the extracted text to Gemini Pro. All requests require a bearer token matching the `API_TOKEN` environment variable.
+
+## Running
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Start the API:
+
+```bash
+uvicorn main:app --reload
+```

--- a/main.py
+++ b/main.py
@@ -1,28 +1,32 @@
-from fastapi import FastAPI, HTTPException, Depends, status
+import logging
+
+from fastapi import (
+    FastAPI,
+    HTTPException,
+    Depends,
+    status,
+    UploadFile,
+    File,
+    Form,
+)
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from fastapi.middleware.cors import CORSMiddleware
 import uvicorn
-import logging
-from typing import List
-import asyncio
 
-from schemas import DocumentQueryRequest, DocumentQueryResponse
 from utils.auth import verify_token
-from utils.gemini_client import GeminiClient
 from utils.pdf_loader import PDFLoader
+from utils.gemini_client import GeminiClient
+from schemas import DocumentQueryResponse
 
-# Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# Initialize FastAPI app
 app = FastAPI(
     title="HACKRX 6.0 - LLM Document Query API",
     description="An intelligent document understanding and retrieval system powered by Gemini Pro",
-    version="1.0.0"
+    version="1.0.0",
 )
 
-# Add CORS middleware
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -31,109 +35,63 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Security scheme
 security = HTTPBearer()
-
-# Initialize components
-gemini_client = GeminiClient()
 pdf_loader = PDFLoader()
+gemini_client = GeminiClient()
 
-async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)):
-    """Verify bearer token authentication"""
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+):
     if not verify_token(credentials.credentials):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid authentication credentials",
+            detail="Invalid token",
             headers={"WWW-Authenticate": "Bearer"},
         )
     return credentials.credentials
 
+
 @app.get("/")
 async def root():
-    """Health check endpoint"""
     return {
         "message": "HACKRX 6.0 - LLM Document Query API",
         "status": "active",
-        "version": "1.0.0"
+        "version": "1.0.0",
     }
+
 
 @app.get("/health")
 async def health_check():
-    """Detailed health check"""
-    try:
-        # Test Gemini client
-        gemini_status = await gemini_client.test_connection()
-        return {
-            "status": "healthy",
-            "gemini_client": "connected" if gemini_status else "disconnected",
-            "pdf_loader": "ready"
-        }
-    except Exception as e:
-        logger.error(f"Health check failed: {str(e)}")
-        return {
-            "status": "unhealthy",
-            "error": str(e)
-        }
+    status_ok = await gemini_client.test_connection()
+    return {"status": "healthy" if status_ok else "unhealthy"}
+
 
 @app.post("/hackrx/run", response_model=DocumentQueryResponse)
-async def process_document_queries(
-    request: DocumentQueryRequest,
-    token: str = Depends(get_current_user)
+async def run_query(
+    question: str = Form(...),
+    file: UploadFile = File(...),
+    token: str = Depends(get_current_user),
 ):
-    """
-    Main endpoint for document understanding and query processing
-    
-    Takes documents and questions, returns intelligent answers using Gemini Pro
-    """
     try:
-        logger.info(f"Processing request with {len(request.questions)} questions")
-        
-        # Extract or process document text
-        document_text = await pdf_loader.process_document(request.documents)
-        
-        if not document_text.strip():
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="No text could be extracted from the document"
-            )
-        
-        logger.info(f"Extracted {len(document_text)} characters from document")
-        
-        # Process questions concurrently for better performance
-        tasks = [
-            gemini_client.answer_question(document_text, question)
-            for question in request.questions
-        ]
-        
-        answers = await asyncio.gather(*tasks, return_exceptions=True)
-        
-        # Handle any exceptions in the results
-        processed_answers = []
-        for i, answer in enumerate(answers):
-            if isinstance(answer, Exception):
-                logger.error(f"Error processing question {i}: {str(answer)}")
-                processed_answers.append(f"Error processing question: {str(answer)}")
-            else:
-                processed_answers.append(answer)
-        
-        logger.info(f"Successfully processed {len(processed_answers)} answers")
-        
-        return DocumentQueryResponse(answers=processed_answers)
-        
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Unexpected error in process_document_queries: {str(e)}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Internal server error: {str(e)}"
-        )
+        document_text = await pdf_loader.extract_text(file)
+    except Exception as exc:
+        logger.error("Failed to load document: %s", exc)
+        raise HTTPException(status_code=400, detail="Failed to read document") from exc
+
+    try:
+        answer = await gemini_client.answer_question(document_text, question)
+    except Exception as exc:
+        logger.error("Gemini processing error: %s", exc)
+        raise HTTPException(status_code=500, detail="LLM processing failed") from exc
+
+    return DocumentQueryResponse(
+        status="success",
+        query=question,
+        answer=answer,
+        file_name=file.filename or "uploaded",
+    )
+
 
 if __name__ == "__main__":
-    uvicorn.run(
-        "main:app",
-        host="127.0.0.1",
-        port=8000,
-        reload=True,
-        log_level="info"
-    )
+    uvicorn.run("main:app", host="127.0.0.1", port=8000, reload=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+python-multipart
+python-dotenv
+PyMuPDF
+google-generativeai

--- a/run.py
+++ b/run.py
@@ -1,0 +1,4 @@
+import uvicorn
+
+if __name__ == "__main__":
+    uvicorn.run("main:app", host="0.0.0.0", port=8000)

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel, Field
+
+
+class DocumentQueryResponse(BaseModel):
+    status: str = Field(..., description="Status of the request")
+    query: str = Field(..., description="User question")
+    answer: str = Field(..., description="LLM generated answer")
+    file_name: str = Field(..., description="Name of the uploaded file")

--- a/test_api.py
+++ b/test_api.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+def test_root():
+    resp = client.get("/")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("status") == "active"

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -1,5 +1,9 @@
 import os
 
-def verify_bearer_token(token: str) -> bool:
-    expected = f"Bearer {os.getenv('HACKRX_AUTH_TOKEN')}"
+
+def verify_token(token: str) -> bool:
+    """Check if the provided token matches the API token."""
+    expected = os.getenv("API_TOKEN")
+    if expected is None:
+        return False
     return token == expected

--- a/utils/pdf_loader.py
+++ b/utils/pdf_loader.py
@@ -1,8 +1,12 @@
-import fitz  # PyMuPDF
+import fitz
+from fastapi import UploadFile
 
-def extract_text_from_pdf(file_path: str) -> str:
-    text = ""
-    with fitz.open(file_path) as doc:
-        for page in doc:
-            text += page.get_text()
-    return text
+
+class PDFLoader:
+    """Utility class to extract text from uploaded PDF files."""
+
+    async def extract_text(self, file: UploadFile) -> str:
+        data = await file.read()
+        with fitz.open(stream=data, filetype="pdf") as doc:
+            text = "".join(page.get_text() for page in doc)
+        return text


### PR DESCRIPTION
## Summary
- implement minimal FastAPI service for querying uploaded PDFs
- add Gemini client wrapper and PDF loader utilities
- provide token auth via `API_TOKEN`
- include example README and test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884807ec9e88320bb3cd50eb995f722