### PR TITLE
Fix bearer auth and env loading

### DIFF
--- a/utils/gemini_client.py
+++ b/utils/gemini_client.py
@@ -18,8 +18,12 @@ class GeminiClient:
         if not api_key:
             raise ValueError("GEMINI_API_KEY not found in environment variables.")
         genai.configure(api_key=api_key)
-        self.model = genai.GenerativeModel("gemini-pro")
+        self.model = None
         logger.info("GeminiClient initialized")
+
+    def _ensure_model(self) -> None:
+        if self.model is None:
+            self.model = genai.GenerativeModel("gemini-pro")
 
     async def answer_question(self, document_text: str, question: str) -> str:
         """Generate an answer for the given question based on the document."""
@@ -30,6 +34,7 @@ class GeminiClient:
         )
         loop = asyncio.get_event_loop()
         try:
+            self._ensure_model()
             response = await loop.run_in_executor(
                 None, lambda: self.model.generate_content(prompt)
             )


### PR DESCRIPTION
## Summary
- load environment variables at startup
- expose bearer token scheme in OpenAPI
- lazy load Gemini client to avoid network on startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884c128eca08320b2197cd6e1609352