### PR TITLE
feat: add flexible run endpoint

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -1,8 +1,12 @@
+from typing import List, Optional
+
 from pydantic import BaseModel, Field
 
 
 class DocumentQueryResponse(BaseModel):
     status: str = Field(..., description="Status of the request")
-    query: str = Field(..., description="User question")
-    answer: str = Field(..., description="LLM generated answer")
-    file_name: str = Field(..., description="Name of the uploaded file")
+    query: List[str] = Field(default_factory=list, description="User questions")
+    answer: List[str] = Field(default_factory=list, description="LLM generated answers")
+    file_name: Optional[str] = Field(
+        None, description="Name of the uploaded file"
+    )


### PR DESCRIPTION
## Summary
- add flexible /hackrx/run handler that accepts JSON or form-data, reads questions or documents, logs raw input and file details
- update response schema to return lists of queries and answers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891afbec6b08320836c6ac89acbaf12