### PR TITLE
Implement multi-document RAG pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ httpx
 pdfminer.six
 sentence-transformers
 faiss-cpu
+PyMuPDF
+python-docx

--- a/schemas.py
+++ b/schemas.py
@@ -1,12 +1,25 @@
+from __future__ import annotations
+
 from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
 
-class DocumentQueryResponse(BaseModel):
+class Answer(BaseModel):
+    decision: str = Field(..., description="Approval decision")
+    amount: Optional[str] = Field(None, description="Approved amount if applicable")
+    justification: str = Field(..., description="Clause reference for the decision")
+
+
+class RetrievedClause(BaseModel):
+    file: str = Field(..., description="Source file name")
+    page: str = Field(..., description="Page number or range")
+    clause: str = Field(..., description="Text of the retrieved clause")
+
+
+class RAGResponse(BaseModel):
     status: str = Field(..., description="Status of the request")
-    query: List[str] = Field(default_factory=list, description="User questions")
-    answer: List[str] = Field(default_factory=list, description="LLM generated answers")
-    file_name: Optional[str] = Field(
-        None, description="Name of the uploaded file"
+    answers: List[Answer] = Field(default_factory=list, description="Answers for each question")
+    retrieved_clauses: List[RetrievedClause] = Field(
+        default_factory=list, description="Clauses used for answering"
     )

--- a/test_multi_doc.py
+++ b/test_multi_doc.py
@@ -1,0 +1,70 @@
+import os
+from io import BytesIO
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+
+os.environ["API_TOKEN"] = "testtoken"
+client = TestClient(app)
+
+
+class DummyVectorStore:
+    async def add_texts(self, texts, metadatas):
+        self.entries = [{**m, "text": t} for t, m in zip(texts, metadatas)]
+
+    async def similarity_search(self, query: str, k: int = 5):
+        return self.entries[:k]
+
+
+async def fake_extract(self, query: str) -> str:
+    return '{"procedure": "knee surgery"}'
+
+
+async def fake_rag(self, question: str, context: str) -> str:
+    return '{"decision": "Approved", "amount": "50000", "justification": "Clause 12.3, Page 1"}'
+
+
+@pytest.fixture(autouse=True)
+def patch_dependencies(monkeypatch):
+    monkeypatch.setattr("utils.vector_store.VectorStore", DummyVectorStore)
+    monkeypatch.setattr("main.VectorStore", DummyVectorStore)
+    monkeypatch.setattr("utils.ollama_client.OllamaClient.extract_entities", fake_extract)
+    monkeypatch.setattr("utils.ollama_client.OllamaClient.rag_answer", fake_rag)
+    from utils.document_loader import Chunk
+
+    async def fake_process_bytes(self, data: bytes, name: str):
+        text = data.decode()
+        return [Chunk(chunk_id=0, file_name=name, page_range="1", text=text)]
+
+    monkeypatch.setattr("utils.document_loader.DocumentLoader.process_bytes", fake_process_bytes)
+
+
+def test_multi_document_query():
+    files = [
+        (
+            "documents",
+            ("doc1.txt", b"Clause 12.3, Page 1: Knee surgery is covered.", "text/plain"),
+        ),
+        (
+            "documents",
+            (
+                "doc2.txt",
+                b"Clause 8.1, Page 5: For knee surgery, maximum amount is 50000 INR.",
+                "text/plain",
+            ),
+        ),
+        (
+            "documents",
+            ("doc3.txt", b"Clause 7.3, Page 9: Heart surgery details.", "text/plain"),
+        ),
+    ]
+    data = {"questions": "46-year-old male, knee surgery in Pune, 3-month-old policy"}
+    headers = {"Authorization": "Bearer testtoken"}
+
+    resp = client.post("/hackrx/run", files=files, data=data, headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["answers"][0]["decision"] == "Approved"
+    assert "Clause" in body["answers"][0]["justification"]

--- a/utils/document_loader.py
+++ b/utils/document_loader.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import re
+from dataclasses import dataclass
+from io import BytesIO
+from typing import List
+
+from fastapi import UploadFile
+
+
+@dataclass
+class Chunk:
+    """Represents a piece of text with tracing metadata."""
+
+    chunk_id: int
+    file_name: str
+    page_range: str
+    text: str
+
+    def metadata(self) -> dict:
+        return {
+            "chunk_id": self.chunk_id,
+            "file_name": self.file_name,
+            "page_range": self.page_range,
+        }
+
+
+class DocumentLoader:
+    """Load multiple document types and chunk them for RAG."""
+
+    def __init__(self, chunk_tokens: int = 1000, overlap_tokens: int = 200) -> None:
+        self.chunk_tokens = chunk_tokens
+        self.overlap_tokens = overlap_tokens
+
+    # --------------------------------------------------------------
+    # Utility helpers
+    # --------------------------------------------------------------
+    def _clean_text(self, text: str) -> str:
+        text = "".join(ch for ch in text if ch.isprintable())
+        text = re.sub(r"\s+", " ", text)
+        return text.strip()
+
+    def _chunk_text(self, text: str) -> List[str]:
+        words = text.split()
+        size = self.chunk_tokens
+        overlap = self.overlap_tokens
+        start = 0
+        chunks: List[str] = []
+        while start < len(words):
+            end = min(len(words), start + size)
+            chunks.append(" ".join(words[start:end]))
+            if end == len(words):
+                break
+            start = end - overlap
+        return chunks
+
+    # --------------------------------------------------------------
+    # Public API
+    # --------------------------------------------------------------
+    async def process_upload(self, upload: UploadFile) -> List[Chunk]:
+        data = await upload.read()
+        await upload.seek(0)
+        return await self.process_bytes(data, upload.filename)
+
+    async def process_base64(self, b64: str, name: str) -> List[Chunk]:
+        try:
+            data = base64.b64decode(b64)
+        except Exception:
+            return []
+        return await self.process_bytes(data, name)
+
+    async def process_bytes(self, data: bytes, file_name: str) -> List[Chunk]:
+        lower = file_name.lower()
+        if lower.endswith(".pdf") or data[:4] == b"%PDF":
+            return await asyncio.to_thread(self._process_pdf, data, file_name)
+        if lower.endswith(".docx"):
+            return await asyncio.to_thread(self._process_docx, data, file_name)
+        # Fallback to plain text
+        return await asyncio.to_thread(
+            self._process_text, data.decode("utf-8", errors="ignore"), file_name
+        )
+
+    # --------------------------------------------------------------
+    # Handlers for specific formats
+    # --------------------------------------------------------------
+    def _process_pdf(self, data: bytes, file_name: str) -> List[Chunk]:
+        import fitz  # PyMuPDF
+
+        doc = fitz.open(stream=data, filetype="pdf")
+        chunks: List[Chunk] = []
+        chunk_id = 0
+        for page_idx, page in enumerate(doc):
+            text = self._clean_text(page.get_text())
+            for piece in self._chunk_text(text):
+                chunks.append(Chunk(chunk_id, file_name, str(page_idx + 1), piece))
+                chunk_id += 1
+        return chunks
+
+    def _process_docx(self, data: bytes, file_name: str) -> List[Chunk]:
+        from docx import Document
+
+        document = Document(BytesIO(data))
+        text = "\n".join(p.text for p in document.paragraphs)
+        cleaned = self._clean_text(text)
+        chunks: List[Chunk] = []
+        chunk_id = 0
+        for piece in self._chunk_text(cleaned):
+            chunks.append(Chunk(chunk_id, file_name, "1", piece))
+            chunk_id += 1
+        return chunks
+
+    def _process_text(self, text: str, file_name: str) -> List[Chunk]:
+        cleaned = self._clean_text(text)
+        chunks: List[Chunk] = []
+        chunk_id = 0
+        for piece in self._chunk_text(cleaned):
+            chunks.append(Chunk(chunk_id, file_name, "1", piece))
+            chunk_id += 1
+        return chunks

--- a/utils/ollama_client.py
+++ b/utils/ollama_client.py
@@ -45,6 +45,26 @@ class OllamaClient:
         )
         return await self.generate(prompt)
 
+    async def extract_entities(self, query: str) -> str:
+        """Extract structured entities from ``query`` as JSON."""
+
+        prompt = (
+            "Extract key details such as age, procedure, location and policy duration "
+            "from the following query. Return a JSON object with these fields if present.\nQuery:\n"
+            f"{query}\nJSON:"
+        )
+        return await self.generate(prompt)
+
+    async def rag_answer(self, question: str, context: str) -> str:
+        """Answer ``question`` using ``context`` and return JSON output."""
+
+        prompt = (
+            "You are an insurance assistant. Use only the provided context to answer the question. "
+            "Respond in JSON with fields: decision, amount, justification.\n\nContext:\n"
+            f"{context}\n\nQuestion:\n{question}\nAnswer JSON:"
+        )
+        return await self.generate(prompt)
+
     async def test_connection(self) -> bool:
         """Basic check to see if the Ollama service is reachable."""
 


### PR DESCRIPTION
## Summary
- Expand API to process multiple documents and questions with per-chunk metadata and FAISS search
- Add document loader for PDF/DOCX/TXT with token-aware chunking and cleaning
- Extend Ollama client and vector store for JSON entity extraction, RAG answers, and metadata-aware similarity search
- Define structured response models and add regression tests for multi-document queries

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689305a23a308320bbb87ef18dec48f8