### PR TITLE
Enhance RAG endpoint for multi-document queries

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -1,25 +1,36 @@
 from __future__ import annotations
 
-from typing import List, Optional
+"""Pydantic schemas for responses returned by the API."""
+
+from typing import List
 
 from pydantic import BaseModel, Field
 
 
-class Answer(BaseModel):
-    decision: str = Field(..., description="Approval decision")
-    amount: Optional[str] = Field(None, description="Approved amount if applicable")
-    justification: str = Field(..., description="Clause reference for the decision")
+class RelevantClause(BaseModel):
+    """Snippet of source text that supports an answer."""
 
-
-class RetrievedClause(BaseModel):
     file: str = Field(..., description="Source file name")
-    page: str = Field(..., description="Page number or range")
-    clause: str = Field(..., description="Text of the retrieved clause")
+    text: str = Field(..., description="Exact text snippet used for the answer")
+
+
+class Answer(BaseModel):
+    """Model representing the answer for a single query."""
+
+    query: str = Field(..., description="Original question")
+    decision: str = Field(..., description="Decision or high level answer")
+    justification: str = Field(..., description="Reasoning behind the decision")
+    relevant_clauses: List[RelevantClause] = Field(
+        default_factory=list,
+        description="Document snippets that support the decision",
+    )
 
 
 class RAGResponse(BaseModel):
+    """Overall response structure returned by the RAG endpoint."""
+
     status: str = Field(..., description="Status of the request")
-    answers: List[Answer] = Field(default_factory=list, description="Answers for each question")
-    retrieved_clauses: List[RetrievedClause] = Field(
-        default_factory=list, description="Clauses used for answering"
+    answers: List[Answer] = Field(
+        default_factory=list, description="Answers for each submitted question"
     )
+

--- a/utils/document_loader.py
+++ b/utils/document_loader.py
@@ -30,7 +30,20 @@ class Chunk:
 class DocumentLoader:
     """Load multiple document types and chunk them for RAG."""
 
-    def __init__(self, chunk_tokens: int = 1000, overlap_tokens: int = 200) -> None:
+    def __init__(self, chunk_tokens: int = 1500, overlap_tokens: int = 200) -> None:
+        """Create a new ``DocumentLoader``.
+
+        Parameters
+        ----------
+        chunk_tokens:
+            Approximate number of tokens (here treated as words) per chunk.  The
+            default of ``1500`` is tuned for large documents (\u2265 1000 pages) so
+            that each piece fed to the language model remains manageable.
+        overlap_tokens:
+            Number of words to overlap between consecutive chunks.  This helps
+            maintain context continuity across chunk boundaries.
+        """
+
         self.chunk_tokens = chunk_tokens
         self.overlap_tokens = overlap_tokens
 


### PR DESCRIPTION
## Summary
- Allow `/hackrx/run` to accept questions under multiple names and handle multi-file uploads in JSON or form-data
- Stream document chunks into a FAISS-based vector store and answer queries with per-file clause references
- Raise 400 when no question is supplied and use larger 1500-token chunks for better large-document handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689338819bec83209795328d906d790d