### PR TITLE
Improve insurance clause retrieval and reasoning

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -26,6 +26,9 @@ class Answer(BaseModel):
         default_factory=list,
         description="Document snippets that support the decision",
     )
+    confidence: str = Field(
+        "", description="Heuristic confidence level for the decision"
+    )
 
 
 class RAGResponse(BaseModel):

--- a/test_edge_cases.py
+++ b/test_edge_cases.py
@@ -1,0 +1,61 @@
+import os
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+
+os.environ["API_TOKEN"] = "testtoken"
+client = TestClient(app)
+
+
+class DummyVectorStore:
+    def __init__(self):
+        self.entries = []
+
+    async def add_texts(self, texts, metadatas):
+        self.entries.extend([{**m, "text": t} for t, m in zip(texts, metadatas)])
+
+    async def similarity_search(self, query: str, k: int = 5, section: str | None = None):
+        # Always return stored entries with score 1.0
+        return [{**e, "score": 1.0} for e in self.entries[:k]]
+
+
+async def fake_extract(self, query: str) -> str:
+    return '{"procedure": "angioplasty"}'
+
+
+@pytest.fixture(autouse=True)
+def patch_dependencies(monkeypatch):
+    monkeypatch.setattr("utils.vector_store.VectorStore", DummyVectorStore)
+    monkeypatch.setattr("main.VectorStore", DummyVectorStore)
+    monkeypatch.setattr("utils.ollama_client.OllamaClient.extract_entities", fake_extract)
+    from utils.document_loader import Chunk
+
+    async def fake_process_bytes(self, data: bytes, name: str):
+        text = data.decode()
+        # text deliberately does not mention angioplasty
+        return [Chunk(chunk_id=0, file_name=name, page_range="1", text=text, section="inclusion")]
+
+    monkeypatch.setattr("utils.document_loader.DocumentLoader.process_bytes", fake_process_bytes)
+
+    async def fake_rag(self, question: str, clauses: list[dict], edge_instruction: str = "") -> str:
+        raise AssertionError("rag_answer should not be called when procedure missing")
+
+    monkeypatch.setattr("utils.ollama_client.OllamaClient.rag_answer", fake_rag)
+
+
+def test_procedure_not_found():
+    files = [
+        (
+            "file",
+            ("doc1.txt", b"General hospitalization is covered.", "text/plain"),
+        )
+    ]
+    data = {"question": "56-year-old male wants angioplasty"}
+    headers = {"Authorization": "Bearer testtoken"}
+
+    resp = client.post("/hackrx/run", files=files, data=data, headers=headers)
+    assert resp.status_code == 200
+    ans = resp.json()["answers"][0]
+    assert ans["decision"] == "insufficient info"
+    assert "do not explicitly mention angioplasty" in ans["justification"].lower()

--- a/test_multi_doc.py
+++ b/test_multi_doc.py
@@ -1,6 +1,4 @@
 import os
-from io import BytesIO
-
 import pytest
 from fastapi.testclient import TestClient
 
@@ -17,16 +15,24 @@ class DummyVectorStore:
     async def add_texts(self, texts, metadatas):
         self.entries.extend([{**m, "text": t} for t, m in zip(texts, metadatas)])
 
-    async def similarity_search(self, query: str, k: int = 5):
-        return self.entries[:k]
+    async def similarity_search(self, query: str, k: int = 5, section: str | None = None):
+        res = []
+        for e in self.entries:
+            if section and e.get("section") != section:
+                continue
+            item = {**e, "score": 1.0}
+            res.append(item)
+            if len(res) >= k:
+                break
+        return res
 
 
 async def fake_extract(self, query: str) -> str:
     return '{"procedure": "knee surgery"}'
 
 
-async def fake_rag(self, question: str, chunks: list[str]) -> str:
-    return '{"decision": "Approved", "amount": "50000", "justification": "Clause 12.3, Page 1"}'
+async def fake_rag(self, question: str, clauses: list[dict], edge_instruction: str = "") -> str:
+    return '{"decision": "approved", "amount": "50000", "justification": "Clause 12.3, Page 1"}'
 
 
 @pytest.fixture(autouse=True)
@@ -39,7 +45,7 @@ def patch_dependencies(monkeypatch):
 
     async def fake_process_bytes(self, data: bytes, name: str):
         text = data.decode()
-        return [Chunk(chunk_id=0, file_name=name, page_range="1", text=text)]
+        return [Chunk(chunk_id=0, file_name=name, page_range="1", text=text, section="inclusion")]
 
     monkeypatch.setattr("utils.document_loader.DocumentLoader.process_bytes", fake_process_bytes)
 
@@ -69,7 +75,7 @@ def test_multi_document_query():
     resp = client.post("/hackrx/run", files=files, data=data, headers=headers)
     assert resp.status_code == 200
     body = resp.json()
-    assert body["answers"][0]["decision"] == "Approved"
+    assert body["answers"][0]["decision"] == "approved"
     assert body["answers"][0]["amount"] == "50000"
     assert body["answers"][0]["query"] == data["question"]
     assert body["answers"][0]["relevant_clauses"][0]["file"] == "doc1.txt"

--- a/utils/document_loader.py
+++ b/utils/document_loader.py
@@ -19,12 +19,14 @@ class Chunk:
     file_name: str
     page_range: str
     text: str
+    section: str = ""
 
     def metadata(self) -> dict:
         return {
             "chunk_id": self.chunk_id,
             "file_name": self.file_name,
             "page_range": self.page_range,
+            "section": self.section,
         }
 
 
@@ -125,7 +127,8 @@ class DocumentLoader:
         chunk_id = 0
         for page_idx, pieces in enumerate(page_texts):
             for piece in pieces:
-                chunks.append(Chunk(chunk_id, file_name, str(page_idx + 1), piece))
+                section = self._infer_section(piece)
+                chunks.append(Chunk(chunk_id, file_name, str(page_idx + 1), piece, section))
                 chunk_id += 1
         return chunks
 
@@ -149,7 +152,8 @@ class DocumentLoader:
         chunks: List[Chunk] = []
         chunk_id = 0
         for piece in self._chunk_text(cleaned):
-            chunks.append(Chunk(chunk_id, file_name, "1", piece))
+            section = self._infer_section(piece)
+            chunks.append(Chunk(chunk_id, file_name, "1", piece, section))
             chunk_id += 1
         return chunks
 
@@ -163,7 +167,8 @@ class DocumentLoader:
         chunks: List[Chunk] = []
         chunk_id = 0
         for piece in self._chunk_text(cleaned):
-            chunks.append(Chunk(chunk_id, file_name, "1", piece))
+            section = self._infer_section(piece)
+            chunks.append(Chunk(chunk_id, file_name, "1", piece, section))
             chunk_id += 1
         return chunks
 
@@ -176,7 +181,8 @@ class DocumentLoader:
         chunks: List[Chunk] = []
         chunk_id = 0
         for piece in self._chunk_text(cleaned):
-            chunks.append(Chunk(chunk_id, file_name, "1", piece))
+            section = self._infer_section(piece)
+            chunks.append(Chunk(chunk_id, file_name, "1", piece, section))
             chunk_id += 1
         return chunks
 
@@ -185,6 +191,20 @@ class DocumentLoader:
         chunks: List[Chunk] = []
         chunk_id = 0
         for piece in self._chunk_text(cleaned):
-            chunks.append(Chunk(chunk_id, file_name, "1", piece))
+            section = self._infer_section(piece)
+            chunks.append(Chunk(chunk_id, file_name, "1", piece, section))
             chunk_id += 1
         return chunks
+
+    # --------------------------------------------------------------
+    # Section inference
+    # --------------------------------------------------------------
+    def _infer_section(self, text: str) -> str:
+        """Very lightweight heuristic to tag text with a section name."""
+
+        lower = text.lower()
+        if "exclusion" in lower:
+            return "exclusion"
+        if any(k in lower for k in ["inclusion", "covered", "coverage", "benefit"]):
+            return "inclusion"
+        return ""


### PR DESCRIPTION
## Summary
- Add section-aware chunking and metadata to document loader for filtering inclusions and exclusions.
- Enhance vector search with semantic similarity, section filtering, and scoring-based confidence.
- Extend RAG pipeline with edge-case handling, structured clause prompts, and confidence field in responses.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689421790b208320bba3c89ea02b86d7